### PR TITLE
add `queue.handleMany` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ queue.handle('foo', squiss.domainify(foo))
 ## Instance API
 
 - [queue.handle](#queuehandle)
+- [queue.handleMany](#queuehandlemany)
 - [queue.on](#queueon)
 - [queue.send](#queuesend)
 - [queue.start](#queuestart)
@@ -121,6 +122,38 @@ for (var type in jobs) {
   queue.handle(type, squiss.domainify(jobs[type]))
 }
 ```
+
+## queue.handleMany
+
+```haskell
+:: (Object) -> Object
+```
+
+#### Parameters
+
+- Object `jobs` <br/>
+  A map of job types to handlers
+
+#### Returns
+
+- Object `queue` <br/>
+  The queue instance.
+
+Similar to [queue.handle](#queuehandle), but registers multiple jobs in one shot.
+
+```js
+const squiss = require('@articulate/squiss-jobs')
+const queue  = require('../lib/queue')
+
+const foo = (payload, done) => {
+  console.log(payload)
+  done()
+}
+
+queue.handleMany('foo', { foo: squiss.domainify(foo) }))
+```
+
+You may also call `queue.handleMany` multiple times to register several sets of jobs.
 
 ## queue.on
 

--- a/index.js
+++ b/index.js
@@ -18,16 +18,18 @@ exports.create = options => {
   })
 
   const handle = (type, handler) => handlers[type] = handler
+  const handleMany = jobs => Object.assign(handlers, jobs)
 
   const on    = consumer.on.bind(consumer),
         start = consumer.start.bind(consumer),
         stop  = consumer.stop.bind(consumer)
 
-  queue.handle = compose(always(queue), handle)
-  queue.on     = compose(always(queue), on)
-  queue.send   = compose(dispatch, action)
-  queue.start  = compose(always(queue), start)
-  queue.stop   = compose(always(queue), stop)
+  queue.handle     = compose(always(queue), handle)
+  queue.handleMany = compose(always(queue), handleMany)
+  queue.on         = compose(always(queue), on)
+  queue.send       = compose(dispatch, action)
+  queue.start      = compose(always(queue), start)
+  queue.stop       = compose(always(queue), stop)
 
   return queue
 }


### PR DESCRIPTION
![handlers](http://img01.deviantart.net/dd64/i/2016/108/8/3/fractal_of_my_scanned_hand_by_radijs_dalfo-d9zd6gb.jpg)

registers multiple jobs in one shot

/cc @flintinatux 