### PR TITLE
Fix for process hanging when message type does not match a handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,6 @@ exports.domainify = fn => (payload, done) => {
 const action = (type, payload) => ({ type, payload })
 
 const handleWith = handlers => ({ type, payload }, done) =>
-  typeof handlers[type] === 'function' ? handlers[type](payload, done) : done(new Error('No Handler registered for (' + type + ')'))
+  typeof handlers[type] === 'function' ? handlers[type](payload, done) : done(new Error(`No Handler registered for (${type})`))
 
 const parseFirst = fn => (msg, done) => fn(parse(msg.Body), done)


### PR DESCRIPTION
fixes issue caused when a message arrives that has a type value that does not match one of the registered handlers.  This scenario causes squiss jobs to wait for what seems to be indefinitely for the done callback to be called.

/cc @flintinatux @pklingem 