### PR TITLE
debug output for exceeded visibility timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,12 +22,15 @@ exports.create = opts => {
     fn(payload, finish)
   }
 
-  const handleWith = ({ type, payload }, done) => {
-    const handler = typeof handlers[type] === 'function'
+  const resolveHandler = (type) => {
+    return typeof handlers[type] === 'function'
       ? handlers[type]
       : (payload, done) => done(new Error(`No Handler registered for (${type})`))
-    const wrappedHandler = wrapWithTimeoutLogger(handler, merge(options, { type, payload }))
-    wrappedHandler(payload, done)
+  }
+
+  const handleWith = ({ type, payload }, done) => {
+    const handler = wrapWithTimeoutLogger(resolveHandler(type), merge(options, { type, payload }))
+    handler(payload, done)
   }
 
   const handleMessage = parseFirst(handleWith),


### PR DESCRIPTION
![visibility](https://www.deliveringinnovation.com/images/InformedVisibility_1.gif)

wraps each handler with function that will log an error when the job execution has exceeded the visibility timeout specified for the queue.  The default logger is the `debug` npm module, however a custom logger function can be provided by passing the `logger` option to `create`.

This was tested with `visibilityTimeout` set to 5 seconds and the following job:

```javascript
const debug = require('debug')('test job')

module.exports = (payload, done) => {
  debug('starting')
  setTimeout(() => {
    debug('finishing')
    done()
  }, 10000)
}
```

generate a job:
```javascript
queue.send('test', { foo: 'bar' })
```

produced the following output:

```
jobs_1       | Thu, 09 Feb 2017 14:47:01 GMT test job starting
jobs_1       | Thu, 09 Feb 2017 14:47:06 GMT squiss-jobs { visibilityTimeout: 5,
jobs_1       |   queueUrl: 'https://queue.amazonaws.com/689543204258/patrick-jobs-pklingemann',
jobs_1       |   region: 'us-east-1',
jobs_1       |   type: 'test',
jobs_1       |   payload: { foo: 'bar' },
jobs_1       |   error: 'visibility timeout exceeded' }
jobs_1       | Thu, 09 Feb 2017 14:47:11 GMT test job finishing
```