### PR TITLE
Create-JobsQueue.ps1: Fix JSON parse error: Pass json argument as single line

### DIFF
--- a/Create-JobsQueue.ps1
+++ b/Create-JobsQueue.ps1
@@ -15,9 +15,7 @@ $deadUri  = (aws sqs create-queue --queue-name $deadName | ConvertFrom-Json).Que
 $deadArn  = (aws sqs get-queue-attributes --queue-url $deadUri --attribute-names QueueArn | ConvertFrom-Json).Attributes.QueueArn
 
 $json = @"
-{
-  \"RedrivePolicy\": \"{\\\"deadLetterTargetArn\\\":\\\"$deadArn\\\",\\\"maxReceiveCount\\\":\\\"3\\\"}\"
-}
+{\"RedrivePolicy\": \"{\\\"deadLetterTargetArn\\\":\\\"$deadArn\\\",\\\"maxReceiveCount\\\":\\\"3\\\"}\"}
 "@
 
 $jobsUri  = (aws sqs create-queue --queue-name ${jobsName} --attributes $json | ConvertFrom-Json).QueueUrl


### PR DESCRIPTION
Prior to this change, I kept getting back the following error:

>Error parsing parameter '--attributes': Invalid JSON: Expecting object: line 1 column 1 (char 0)
>JSON received: {

@jameswelle Not sure why I ran into this but you didn't. Any ideas? Either way, this seems to fix the problem.